### PR TITLE
🎨 Palette: Add keyboard navigation to sidebar webview

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Interactive Div Accessibility in VS Code Webviews
+**Learning:** Found that custom `div`-based list items in the sidebar (like `.finding-item`) were used as primary interactive elements to open files, but lacked keyboard accessibility. Only mouse clicks were supported via `onclick`.
+**Action:** Always verify that interactive elements that are not native `<button>` or `<a>` tags include `role="button"`, `tabindex="0"`, and `onkeydown` event handlers to capture `Enter` and `Space` key events, ensuring full access for keyboard-only users in custom VS Code webviews.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -70,11 +70,19 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         // ─── Findings section ─────────────────────────────
         let findingsHtml = '';
         if (this.scanResults.length > 0) {
-            const items = this.scanResults.slice(0, 8).map(f => `
-                <div class="finding-item" onclick="vscode.postMessage({type:'action', command:'quell.openFile', args:['${f.file.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}']})">
+            const items = this.scanResults.slice(0, 8).map(f => {
+                const escapedFile = f.file.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+                return `
+                <div class="finding-item"
+                    role="button"
+                    tabindex="0"
+                    onclick="vscode.postMessage({type:'action', command:'quell.openFile', args:['${escapedFile}']})"
+                    onkeydown="if(event.key === 'Enter' || event.key === ' ') { event.preventDefault(); vscode.postMessage({type:'action', command:'quell.openFile', args:['${escapedFile}']}); }"
+                >
                     <span class="finding-file" title="${f.file}">${f.file}</span>
                     <span class="finding-count" title="${f.count} secret(s)">${f.count}</span>
-                </div>`).join('');
+                </div>`;
+            }).join('');
             const moreTag = this.scanResults.length > 8
                 ? `<div class="finding-more">+${this.scanResults.length - 8} more files</div>` : '';
             findingsHtml = `
@@ -415,6 +423,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                     transform: translateY(-1px);
                 }
                 .btn-cta:active { transform: translateY(0) scale(0.99); }
+                .btn-cta:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
                 .btn-cta svg { width: 14px; height: 14px; }
 
                 /* ── Tool grid ──────────────────────── */
@@ -451,6 +460,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                 .btn-tool:active { transform: translateY(0) scale(0.97); }
                 .btn-tool svg { width: 14px; height: 14px; flex-shrink: 0; color: var(--accent); transition: all 0.2s; }
                 .btn-tool:hover svg { transform: rotate(-5deg) scale(1.1); filter: drop-shadow(0 0 4px var(--accent)); }
+                .btn-tool:focus-visible { outline: 2px solid var(--accent-bright); outline-offset: 2px; }
                 .btn-tool span { overflow: hidden; text-overflow: ellipsis; }
 
                 /* ── Stats row ──────────────────────── */
@@ -566,6 +576,11 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                 }
                 .finding-item:active {
                     transform: scale(0.99);
+                }
+                .finding-item:focus-visible {
+                    outline: 2px solid var(--accent-bright);
+                    outline-offset: -2px;
+                    background: rgba(251,113,133,0.08);
                 }
                 .finding-item:last-child { border-bottom: none; }
                 .finding-file {


### PR DESCRIPTION
💡 What: The UX enhancement added `role="button"`, `tabindex="0"`, and `onkeydown` support to the `.finding-item` list items in the sidebar webview so they can be activated with `Enter` and `Space`. Also added `:focus-visible` styles to interactive elements (`.btn-cta`, `.btn-tool`, `.finding-item`) for better keyboard navigation visibility.
🎯 Why: The user problem it solves is that custom `div`-based list items were used as primary interactive elements to open files, but lacked keyboard accessibility. Only mouse clicks were supported via `onclick`.
♿ Accessibility: Improved keyboard navigation and focus visibility for screen reader and keyboard-only users.

---
*PR created automatically by Jules for task [2434642740450491642](https://jules.google.com/task/2434642740450491642) started by @Sonofg0tham*