### PR TITLE
🛡️ Sentinel: [HIGH] Fix Base64 False Negative and GitHub PAT Scanning

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Fix Base64 False Negative
+**Vulnerability:** A regex meant to skip camelCase/PascalCase identifiers (`/^[a-zA-Z_$][a-zA-Z0-9_$]*$/`) was too forgiving and allowed digits, causing it to skip high-entropy base64-like tokens that didn't contain any other special characters.
+**Learning:** Pure-alpha identifiers must be strictly checked using `/^[a-zA-Z]+$/` to ensure digits aren't accidentally matched in high-entropy checks. Otherwise, base64 strings might pass off as camelCase words.
+**Prevention:** Thoroughly ensure that exception patterns do not overlap with legitimate high-entropy formats, particularly with respect to mixed alphanumeric content.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,47 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: 20.x
+        version: 20.19.37
+      '@types/vscode':
+        specifier: ^1.85.0
+        version: 1.110.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
+packages:
+
+  '@types/node@20.19.37':
+    resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
+
+  '@types/vscode@1.110.0':
+    resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@types/node@20.19.37':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/vscode@1.110.0': {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/src/SecretScanner.ts
+++ b/src/SecretScanner.ts
@@ -71,7 +71,7 @@ export class SecretScanner {
         { name: 'GitHub App Token', regex: /ghu_[a-zA-Z0-9]{36}/ },
         { name: 'GitHub App Server Token', regex: /ghs_[a-zA-Z0-9]{36}/ },
         { name: 'GitHub App Refresh Token', regex: /ghr_[a-zA-Z0-9]{36}/ },
-        { name: 'GitHub Fine-grained PAT', regex: /github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}/ },
+        { name: 'GitHub Fine-grained PAT', regex: /github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{57,59}/ },
         { name: 'GitLab Personal Access Token', regex: /glpat-[0-9A-Za-z\-_]{20}/ },
         { name: 'GitLab Pipeline Trigger Token', regex: /glptt-[0-9a-f]{40}/ },
         { name: 'GitLab Runner Token', regex: /glrt-[0-9A-Za-z\-_]{20}/ },
@@ -275,7 +275,7 @@ export class SecretScanner {
                 if (/^[A-Z][A-Z0-9]*(_[A-Z0-9]+)+$/.test(token)) { continue; }
 
                 // Skip camelCase / PascalCase identifiers that are purely alpha (e.g. handlePasswordChange, scoreError)
-                if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(token) && /[a-z]/.test(token) && /[A-Z]/.test(token)) { continue; }
+                if (/^[a-zA-Z]+$/.test(token) && /[a-z]/.test(token) && /[A-Z]/.test(token)) { continue; }
 
                 // Skip environment variable references (import.meta.env.*, process.env.*)
                 if (/^(import\.meta\.env|process\.env)\./i.test(token)) { continue; }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The high-entropy base64 string scanner skipped over alphanumeric strings entirely if they contained no special characters, treating them as camelCase variables.
🎯 Impact: High entropy secrets like tokens that lack special characters could be silently ignored by the scanner and potentially exposed.
🔧 Fix: Tightened the skip rule for camelCase/PascalCase identifiers in `src/SecretScanner.ts` to `/^[a-zA-Z]+$/`. This ensures only purely alphabetic strings are bypassed. Additionally, updated the GitHub PAT regex to support token suffix lengths ranging from 57 to 59.
✅ Verification: `pnpm test` confirms that base64-like tokens and different variations of GitHub PATs are now successfully detected.

---
*PR created automatically by Jules for task [5503264168248456682](https://jules.google.com/task/5503264168248456682) started by @Sonofg0tham*