### PR TITLE
🛡️ Sentinel: [HIGH] Fix Webview XSS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - XSS in Webview UI
+**Vulnerability:** User-controlled file paths (`scanResults`) were directly interpolated into VS Code Webview HTML without escaping, creating an XSS vulnerability if a malicious file name was indexed.
+**Learning:** Webviews with `'unsafe-inline'` script Content-Security-Policy rules are vulnerable to DOM/HTML injection. Even seemingly benign data like file paths can be crafted maliciously (e.g., `"><script>alert(1)</script>`) to execute arbitrary Javascript within the webview context.
+**Prevention:** Always rigorously HTML-escape dynamic content using an escaping function before injecting it into Webview HTML template literals. Use `.replace(/[&<>"']/g, ...)` to ensure characters like `&`, `<`, `>`, `"`, and `'` are safely transformed into their corresponding HTML entities.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,47 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: 20.x
+        version: 20.19.37
+      '@types/vscode':
+        specifier: ^1.85.0
+        version: 1.110.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
+packages:
+
+  '@types/node@20.19.37':
+    resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
+
+  '@types/vscode@1.110.0':
+    resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@types/node@20.19.37':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/vscode@1.110.0': {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -67,19 +67,30 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         const customCount = config.get<Array<unknown>>('customPatterns', []).length;
         const totalPatterns = SecretScanner.patternCount + customCount;
 
+        const escapeHtml = (unsafe: string): string => {
+            return unsafe
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#039;");
+        };
+
         // ─── Findings section ─────────────────────────────
         let findingsHtml = '';
         if (this.scanResults.length > 0) {
             const items = this.scanResults.slice(0, 8).map(f => {
-                const escapedFile = f.file.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+                const escapedFileJs = f.file.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+                const safeFileJs = escapeHtml(escapedFileJs);
+                const safeFile = escapeHtml(f.file);
                 return `
                 <div class="finding-item"
                     role="button"
                     tabindex="0"
-                    onclick="vscode.postMessage({type:'action', command:'quell.openFile', args:['${escapedFile}']})"
-                    onkeydown="if(event.key === 'Enter' || event.key === ' ') { event.preventDefault(); vscode.postMessage({type:'action', command:'quell.openFile', args:['${escapedFile}']}); }"
+                    onclick="vscode.postMessage({type:'action', command:'quell.openFile', args:['${safeFileJs}']})"
+                    onkeydown="if(event.key === 'Enter' || event.key === ' ') { event.preventDefault(); vscode.postMessage({type:'action', command:'quell.openFile', args:['${safeFileJs}']}); }"
                 >
-                    <span class="finding-file" title="${f.file}">${f.file}</span>
+                    <span class="finding-file" title="${safeFile}">${safeFile}</span>
                     <span class="finding-count" title="${f.count} secret(s)">${f.count}</span>
                 </div>`;
             }).join('');


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Unescaped user-controlled string interpolation (XSS) in VS Code Webviews.
🎯 **Impact**: If a user had a maliciously named file (e.g., \`"><script>alert(1)</script>\`) matched by the Quell Secret Scanner, the resulting file path would be rendered directly into the VS Code Webview HTML. This allowed for arbitrary Javascript execution within the context of the VS Code extension webview.
🔧 **Fix**: Implemented a robust \`escapeHtml\` function in \`SidebarProvider.ts\` and meticulously applied it to HTML text content and element attributes. The logic also carefully double-escapes the string variables used in inline JS event handlers (like \`onclick\`) to close all possible injection vectors.
✅ **Verification**:
1. Open a workspace with a file named \`"><script>alert(1)</script>\`.
2. Ensure that file contains a string that gets flagged by Quell.
3. Observe the Webview UI. Ensure the file name is rendered exactly as text instead of breaking the HTML layout or firing a JS alert.

---
*PR created automatically by Jules for task [427893666726118271](https://jules.google.com/task/427893666726118271) started by @Sonofg0tham*