### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in SidebarProvider

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-24 - Unescaped Dynamic Data in Webview Event Handlers
+**Vulnerability:** Potential Cross-Site Scripting (XSS) vulnerability via unescaped file paths rendered inside inline JavaScript event handlers (e.g. `onclick`) and HTML attributes in the `SidebarProvider` webview.
+**Learning:** Since the Webview CSP allows 'unsafe-inline' scripts, any dynamically injected data (like a file path containing a single quote or HTML tags) can escape the context and execute arbitrary code within the webview. Simple string replacement (e.g., `replace(/\\/g, '\\\\').replace(/'/g, "\\'")`) is insufficient for complete safety.
+**Prevention:** Always rigorously HTML-escape dynamic data before interpolating it into HTML strings. For data inside inline JavaScript event handlers, it must be appropriately JavaScript-escaped AND HTML-escaped using private helper methods like `_escapeJs` and `_escapeHtml`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,47 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: 20.x
+        version: 20.19.37
+      '@types/vscode':
+        specifier: ^1.85.0
+        version: 1.110.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
+packages:
+
+  '@types/node@20.19.37':
+    resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
+
+  '@types/vscode@1.110.0':
+    resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@types/node@20.19.37':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/vscode@1.110.0': {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -58,6 +58,24 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         }
     }
 
+    private _escapeHtml(unsafe: string): string {
+        return unsafe
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#039;");
+    }
+
+    private _escapeJs(unsafe: string): string {
+        return unsafe
+            .replace(/\\/g, "\\\\")
+            .replace(/'/g, "\\'")
+            .replace(/"/g, "\\\"")
+            .replace(/\n/g, "\\n")
+            .replace(/\r/g, "\\r");
+    }
+
     private getHtmlForWebview(): string {
         const config = vscode.workspace.getConfiguration('quell');
         const iconUri = this._view?.webview.asWebviewUri(
@@ -71,7 +89,9 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         let findingsHtml = '';
         if (this.scanResults.length > 0) {
             const items = this.scanResults.slice(0, 8).map(f => {
-                const escapedFile = f.file.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+                const escapedFile = this._escapeHtml(this._escapeJs(f.file));
+                const escapedTitle = this._escapeHtml(f.file);
+                const escapedDisplay = this._escapeHtml(f.file);
                 return `
                 <div class="finding-item"
                     role="button"
@@ -79,7 +99,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                     onclick="vscode.postMessage({type:'action', command:'quell.openFile', args:['${escapedFile}']})"
                     onkeydown="if(event.key === 'Enter' || event.key === ' ') { event.preventDefault(); vscode.postMessage({type:'action', command:'quell.openFile', args:['${escapedFile}']}); }"
                 >
-                    <span class="finding-file" title="${f.file}">${f.file}</span>
+                    <span class="finding-file" title="${escapedTitle}">${escapedDisplay}</span>
                     <span class="finding-count" title="${f.count} secret(s)">${f.count}</span>
                 </div>`;
             }).join('');


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** Unescaped dynamic data (file paths) were being interpolated directly into HTML strings and inline JavaScript event handlers (`onclick`, `onkeydown`) within the `SidebarProvider` webview. Due to the `'unsafe-inline'` Content Security Policy, this allowed for potential Cross-Site Scripting (XSS) if a file path contained specific characters like double quotes.
**🎯 Impact:** A malicious file path could break out of the HTML attribute or JavaScript string literal context, allowing arbitrary script execution within the context of the VS Code extension's webview.
**🔧 Fix:** Implemented `_escapeHtml` and `_escapeJs` private methods in the `SidebarProvider` class. Applied these methods to strictly escape file paths before they are injected into the HTML string, specifically using both JavaScript and HTML escaping for the inline event handlers.
**✅ Verification:** Compiled the project and ran `pnpm test` successfully. Verified that the `SidebarProvider` now properly escapes characters like quotes and brackets in file names before rendering them in the webview. Included an entry in `.jules/sentinel.md` documenting this pattern.

---
*PR created automatically by Jules for task [91873194208966803](https://jules.google.com/task/91873194208966803) started by @Sonofg0tham*