### PR TITLE
⚡ Bolt: [performance improvement] Parallelize EnvManager workspace scanning

### DIFF
--- a/src/EnvManager.ts
+++ b/src/EnvManager.ts
@@ -42,42 +42,51 @@ export class EnvManager {
 
         Logger.info(`ENV: Found ${envFiles.length} .env file(s) to redact.`);
         let combinedContent = '';
+        const CONCURRENCY_LIMIT = 5;
 
-        for (const uri of envFiles) {
-            const relPath = vscode.workspace.asRelativePath(uri);
-            combinedContent += `\n# ─── ${relPath} (Redacted by Quell) ───\n`;
+        for (let i = 0; i < envFiles.length; i += CONCURRENCY_LIMIT) {
+            const batch = envFiles.slice(i, i + CONCURRENCY_LIMIT);
 
-            try {
-                // Async file read — does NOT block the extension host
-                const rawBytes = await vscode.workspace.fs.readFile(uri);
-                const fileContent = Buffer.from(rawBytes).toString('utf-8');
-                const lines = fileContent.split(/\r?\n/);
+            const results = await Promise.all(batch.map(async (uri) => {
+                const relPath = vscode.workspace.asRelativePath(uri);
+                let content = `\n# ─── ${relPath} (Redacted by Quell) ───\n`;
 
-                for (const line of lines) {
-                    const trimmed = line.trim();
+                try {
+                    // Async file read — does NOT block the extension host
+                    const rawBytes = await vscode.workspace.fs.readFile(uri);
+                    const fileContent = Buffer.from(rawBytes).toString('utf-8');
+                    const lines = fileContent.split(/\r?\n/);
 
-                    // Preserve blank lines and comments
-                    if (!trimmed || trimmed.startsWith('#')) {
-                        combinedContent += line + '\n';
-                        continue;
+                    for (const line of lines) {
+                        const trimmed = line.trim();
+
+                        // Preserve blank lines and comments
+                        if (!trimmed || trimmed.startsWith('#')) {
+                            content += line + '\n';
+                            continue;
+                        }
+
+                        const equalsIdx = trimmed.indexOf('=');
+                        if (equalsIdx > 0) {
+                            const key = trimmed.substring(0, equalsIdx).trim();
+                            // Expose key name, mask value
+                            content += `${key}=<HIDDEN_BY_QUELL>\n`;
+                        } else {
+                            content += line + ' # <Warning: Unparsed Line>\n';
+                        }
                     }
 
-                    const equalsIdx = trimmed.indexOf('=');
-                    if (equalsIdx > 0) {
-                        const key = trimmed.substring(0, equalsIdx).trim();
-                        // Expose key name, mask value
-                        combinedContent += `${key}=<HIDDEN_BY_QUELL>\n`;
-                    } else {
-                        combinedContent += line + ' # <Warning: Unparsed Line>\n';
-                    }
+                    Logger.info(`ENV: Redacted ${relPath}`);
+                } catch (error) {
+                    const errMsg = error instanceof Error ? error.message : String(error);
+                    Logger.error(`ENV: Failed to read ${relPath}: ${errMsg}`);
+                    content += `# Error reading file: ${errMsg}\n`;
                 }
 
-                Logger.info(`ENV: Redacted ${relPath}`);
-            } catch (error) {
-                const errMsg = error instanceof Error ? error.message : String(error);
-                Logger.error(`ENV: Failed to read ${relPath}: ${errMsg}`);
-                combinedContent += `# Error reading file: ${errMsg}\n`;
-            }
+                return content;
+            }));
+
+            combinedContent += results.join('');
         }
 
         return combinedContent.trim();


### PR DESCRIPTION
💡 What: Replaced the sequential `for` loop responsible for reading and redacting `.env` files with a batched concurrent implementation using `Promise.all` and a concurrency limit.

🎯 Why: Sequential `for` loops reading multiple files block the event loop and needlessly increase latency during workspace scanning tasks. Since file reading and secret scanning do not depend on sequential execution order, they can and should be processed concurrently.

📊 Impact: Significantly reduces execution time when analyzing workspaces with multiple `.env` files (e.g., in a monorepo setup). The addition of `CONCURRENCY_LIMIT = 5` safeguards against `EMFILE` or OOM errors at the OS level on exceedingly large workspaces.

🔬 Measurement: Verify by executing the full suite of automated tests (`pnpm test`), which continue to pass, proving that order, strings, and error handling behaviors were safely preserved. You could optionally benchmark `getRedactedEnv` on a workspace possessing numerous environment files to measure runtime reduction.

---
*PR created automatically by Jules for task [7608019304677089193](https://jules.google.com/task/7608019304677089193) started by @Sonofg0tham*