### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Webview Command Execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-26 - Arbitrary Command Execution from Webview
+**Vulnerability:** The webview handler `onDidReceiveMessage` accepted any `command` string from `webview.postMessage` and directly passed it to `vscode.commands.executeCommand`. This could allow an attacker who achieved XSS in the webview to execute arbitrary VS Code commands.
+**Learning:** Webviews in VS Code are highly privileged environments if they have access to `executeCommand`. Never trust inputs sent from the webview back to the extension host.
+**Prevention:** Implement strict whitelisting or pattern matching (e.g., ensuring `command.startsWith('extensionName.')`) for commands coming from webviews.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: 20.x
         version: 20.19.37
       '@types/vscode':
-        specifier: ^1.85.0
+        specifier: ^1.110.0
         version: 1.110.0
       typescript:
         specifier: ^5.3.3

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -25,6 +25,11 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
+                    // Security: Prevent arbitrary command execution from webview
+                    if (typeof data.command !== 'string' || !data.command.startsWith('quell.')) {
+                        console.warn(`Blocked unauthorized command attempt from webview: ${data.command}`);
+                        return;
+                    }
                     if (data.args) {
                         vscode.commands.executeCommand(data.command, ...data.args);
                     } else {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The webview handler `onDidReceiveMessage` accepted any `command` string from the webview and directly passed it to `vscode.commands.executeCommand`. This allows an attacker who achieves XSS in the webview to execute arbitrary VS Code commands (e.g., executing terminal scripts, opening files, deleting files).
🎯 **Impact:** Complete system compromise if XSS is present. Webview scripts could tell VS Code to execute malicious payloads or access the host filesystem.
🔧 **Fix:** Added validation in `SidebarProvider.ts` to ensure that `data.command` must be a string and must start with the `quell.` prefix before it can be executed. Any non-authorized commands are logged to the console and ignored.
✅ **Verification:**
1. Ran `pnpm run compile` to verify TypeScript builds successfully.
2. Ran `pnpm test` to verify no existing logic is broken.
3. Examined code logic to ensure only `quell.` commands pass the check.

---
*PR created automatically by Jules for task [4583822906364389788](https://jules.google.com/task/4583822906364389788) started by @Sonofg0tham*