### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix arbitrary command execution via webview messaging

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - Arbitrary Command Execution via Webview Messaging
+**Vulnerability:** The webview message handler in `SidebarProvider.ts` blindly passed arbitrary command strings from the webview to `vscode.commands.executeCommand`. If an attacker achieved XSS in the webview (e.g. via an unsanitized path), they could execute any VS Code command.
+**Learning:** `vscode.commands.executeCommand` is a powerful API. Since webviews can run untrusted content and are susceptible to XSS, any messages they send back to the extension host must be treated as untrusted input and strictly validated.
+**Prevention:** Always whitelist or validate command strings originating from webviews. For example, ensure the command starts with the extension's prefix (`quell.`).

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -25,10 +25,16 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
-                    if (data.args) {
-                        vscode.commands.executeCommand(data.command, ...data.args);
+                    // Security: Strictly validate that the command string is a legitimate Quell command.
+                    // This prevents arbitrary command execution vulnerabilities from potential XSS.
+                    if (typeof data.command === 'string' && data.command.startsWith('quell.')) {
+                        if (data.args) {
+                            vscode.commands.executeCommand(data.command, ...data.args);
+                        } else {
+                            vscode.commands.executeCommand(data.command);
+                        }
                     } else {
-                        vscode.commands.executeCommand(data.command);
+                        console.warn(`[Quell] Blocked unauthorized command execution attempt: ${data.command}`);
                     }
                     break;
             }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The webview message handler in `SidebarProvider.ts` blindly passed arbitrary command strings from the webview to `vscode.commands.executeCommand`. If an attacker achieved XSS in the webview (e.g., via an unsanitized path), they could execute any VS Code command.
🎯 Impact: Could allow an attacker to execute arbitrary local code or built-in VS Code commands via malicious input that achieves XSS in the webview.
🔧 Fix: Added a strict validation check to ensure that the command string starts with the `'quell.'` prefix before calling `vscode.commands.executeCommand`. Added fallback logic to log unauthorized command execution attempts.
✅ Verification: Ran `pnpm compile` and `pnpm test` successfully. Verified the fix by confirming that commands in the webview still execute properly (as they are prefixed with `quell.`). Added documentation for this vulnerability pattern in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6800872274489707365](https://jules.google.com/task/6800872274489707365) started by @Sonofg0tham*