### PR TITLE
⚡ Bolt: Implement batched concurrent `.env` file reading

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Parallelize I/O-bound tasks in workspace scans
 **Learning:** Sequential `for` loops reading files block the event loop and increase latency for workspace scanning tasks. Since file reading and secret scanning don't depend on sequential execution order, they can be processed concurrently.
 **Action:** Parallelize I/O-bound tasks in workspace scans (like file reading and secret scanning) using `Promise.all` with `.map()` instead of sequential `for` loops to significantly reduce execution time.
+
+## 2024-06-03 - Batched concurrent processing for I/O-bound tasks
+**Learning:** Unconstrained `Promise.all(files.map(...))` for processing a large number of files can cause EMFILE/OOM errors on large workspaces.
+**Action:** Use batched concurrent processing (e.g., `for` loop with sliced batches and `Promise.all`) instead of unconstrained `Promise.all` to prevent EMFILE/OOM errors and to allow CancellationToken checks between batches.

--- a/src/EnvManager.ts
+++ b/src/EnvManager.ts
@@ -43,41 +43,52 @@ export class EnvManager {
         Logger.info(`ENV: Found ${envFiles.length} .env file(s) to redact.`);
         let combinedContent = '';
 
-        for (const uri of envFiles) {
-            const relPath = vscode.workspace.asRelativePath(uri);
-            combinedContent += `\n# ─── ${relPath} (Redacted by Quell) ───\n`;
+        const CONCURRENCY_LIMIT = 5;
+        const total = envFiles.length;
 
-            try {
-                // Async file read — does NOT block the extension host
-                const rawBytes = await vscode.workspace.fs.readFile(uri);
-                const fileContent = Buffer.from(rawBytes).toString('utf-8');
-                const lines = fileContent.split(/\r?\n/);
+        for (let i = 0; i < total; i += CONCURRENCY_LIMIT) {
+            const batch = envFiles.slice(i, i + CONCURRENCY_LIMIT);
 
-                for (const line of lines) {
-                    const trimmed = line.trim();
+            const batchResults = await Promise.all(batch.map(async (uri) => {
+                const relPath = vscode.workspace.asRelativePath(uri);
+                let fileResult = `\n# ─── ${relPath} (Redacted by Quell) ───\n`;
 
-                    // Preserve blank lines and comments
-                    if (!trimmed || trimmed.startsWith('#')) {
-                        combinedContent += line + '\n';
-                        continue;
+                try {
+                    // Async file read — does NOT block the extension host
+                    const rawBytes = await vscode.workspace.fs.readFile(uri);
+                    const fileContent = Buffer.from(rawBytes).toString('utf-8');
+                    const lines = fileContent.split(/\r?\n/);
+
+                    for (const line of lines) {
+                        const trimmed = line.trim();
+
+                        // Preserve blank lines and comments
+                        if (!trimmed || trimmed.startsWith('#')) {
+                            fileResult += line + '\n';
+                            continue;
+                        }
+
+                        const equalsIdx = trimmed.indexOf('=');
+                        if (equalsIdx > 0) {
+                            const key = trimmed.substring(0, equalsIdx).trim();
+                            // Expose key name, mask value
+                            fileResult += `${key}=<HIDDEN_BY_QUELL>\n`;
+                        } else {
+                            fileResult += line + ' # <Warning: Unparsed Line>\n';
+                        }
                     }
 
-                    const equalsIdx = trimmed.indexOf('=');
-                    if (equalsIdx > 0) {
-                        const key = trimmed.substring(0, equalsIdx).trim();
-                        // Expose key name, mask value
-                        combinedContent += `${key}=<HIDDEN_BY_QUELL>\n`;
-                    } else {
-                        combinedContent += line + ' # <Warning: Unparsed Line>\n';
-                    }
+                    Logger.info(`ENV: Redacted ${relPath}`);
+                } catch (error) {
+                    const errMsg = error instanceof Error ? error.message : String(error);
+                    Logger.error(`ENV: Failed to read ${relPath}: ${errMsg}`);
+                    fileResult += `# Error reading file: ${errMsg}\n`;
                 }
 
-                Logger.info(`ENV: Redacted ${relPath}`);
-            } catch (error) {
-                const errMsg = error instanceof Error ? error.message : String(error);
-                Logger.error(`ENV: Failed to read ${relPath}: ${errMsg}`);
-                combinedContent += `# Error reading file: ${errMsg}\n`;
-            }
+                return fileResult;
+            }));
+
+            combinedContent += batchResults.join('');
         }
 
         return combinedContent.trim();


### PR DESCRIPTION
*   **💡 What:** Implemented batched concurrent processing for reading `.env` files in `EnvManager.ts` and updated `.jules/bolt.md` with the new learning.
*   **🎯 Why:** Reading `.env` files sequentially blocks the event loop unnecessarily. Concurrent reading is much faster but unconstrained concurrency (`Promise.all(files.map(...))`) risks EMFILE errors. Batched concurrency solves both issues.
*   **📊 Impact:** Expected to significantly reduce latency when scanning workspaces with multiple `.env` files (e.g., `.env`, `.env.local`, `.env.test`), while maintaining stability by bounding concurrency to 5.
*   **🔬 Measurement:** Run `pnpm test` to ensure no regressions in secret scanning. In a large workspace with 10+ `.env` files, observe faster execution time for the `quell.scanWorkspace` command or `/context` chat command.

---
*PR created automatically by Jules for task [17709828337217525932](https://jules.google.com/task/17709828337217525932) started by @Sonofg0tham*