### PR TITLE
🎨 Palette: Add ARIA alert roles to dynamic clipboard warning

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-15 - Stateful Toggle Button Accessibility in Webviews
 **Learning:** Toggle buttons (like "AI Indexing Shield") visually indicated their state via CSS classes (`.on`/`.off`) and text ("ON"/"OFF"), but lacked semantic `aria-pressed` states for screen readers. Furthermore, while primary buttons (`.btn-cta`, `.btn-tool`) had `:focus-visible` styles for keyboard navigation, the smaller `.toggle-btn` elements did not, making keyboard tabbing invisible.
 **Action:** Always ensure custom toggle buttons include dynamic `aria-pressed="true|false"` attributes and that ALL interactive elements receive explicit `:focus-visible` styling to support keyboard navigation in custom VS Code webviews.
+
+## 2024-05-16 - Dynamically Injected Warning Banners in Webviews
+**Learning:** Found that dynamically injected warning banners (like the clipboard warning in the sidebar) appeared visually but were not announced by screen readers when they popped up, as they lacked ARIA live region attributes.
+**Action:** Always ensure that dynamically appearing alert or warning banners in custom VS Code webviews include `role="alert"` or `aria-live="assertive"` so that assistive technologies announce the urgent information immediately upon injection.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -136,7 +136,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 
         // ─── Clipboard warning ─────────────────────────────
         const clipboardBanner = this._clipboardWarning ? `
-            <div class="clipboard-warning">
+            <div class="clipboard-warning" role="alert" aria-live="assertive">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
                 <span>Secret in clipboard! Use <kbd>Ctrl+Shift+C</kbd> to safely copy.</span>
             </div>` : '';


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` to the clipboard warning banner in the `SidebarProvider`.
🎯 Why: The clipboard warning banner is injected dynamically when a secret is detected. Screen readers were not announcing this dynamically appearing banner, leaving visually impaired users unaware of the urgent warning.
📸 Before/After: Visual UI remains unchanged.
♿ Accessibility: Ensures the urgent clipboard warning is properly announced to screen reader users as soon as it appears.

---
*PR created automatically by Jules for task [2832665470146496234](https://jules.google.com/task/2832665470146496234) started by @Sonofg0tham*