### PR TITLE
⚡ Bolt: Cache RegExp Compilations in Secret Scanner Hot Path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Parallelize I/O-bound tasks in workspace scans
 **Learning:** Sequential `for` loops reading files block the event loop and increase latency for workspace scanning tasks. Since file reading and secret scanning don't depend on sequential execution order, they can be processed concurrently.
 **Action:** Parallelize I/O-bound tasks in workspace scans (like file reading and secret scanning) using `Promise.all` with `.map()` instead of sequential `for` loops to significantly reduce execution time.
+
+## 2024-11-06 - Avoid redundant RegExp recompilation in hot paths
+**Learning:** Compiling configuration-driven regex patterns (like user custom patterns or whitelists) repeatedly inside a frequently called function (like `SecretScanner.redact`) causes severe performance overhead, especially during mass file scans (e.g., workspace scans).
+**Action:** Cache these compiled `RegExp` objects locally (e.g., using a `WeakMap` keyed by the original configuration array) so they are only compiled once per unique configuration, bypassing massive overhead during workspace scans.

--- a/src/SecretScanner.ts
+++ b/src/SecretScanner.ts
@@ -169,6 +169,10 @@ export class SecretScanner {
             regex: new RegExp(p.regex.source, p.regex.flags.includes('g') ? p.regex.flags : p.regex.flags + 'g'),
         }));
 
+    // Cache user-provided patterns to avoid redundant RegExp recompilation in hot paths (like workspace scans)
+    private static readonly _whitelistCache = new WeakMap<string[], RegExp[]>();
+    private static readonly _customPatternCache = new WeakMap<Array<{ name: string; regex: string }>, Array<{ name: string; regex: RegExp }>>();
+
     // ═════════════════════════════════════════
     //  Public API
     // ═════════════════════════════════════════
@@ -185,10 +189,14 @@ export class SecretScanner {
         const secrets = new Map<string, string>();
         const detectedTypes = new Set<string>();
 
-        // Build whitelist regex set
-        const whitelistRegexps = config.whitelistPatterns
-            .map((p) => { try { return new RegExp(p); } catch { return null; } })
-            .filter((r): r is RegExp => r !== null);
+        // Build whitelist regex set (cached to prevent recompilation on every file scan)
+        let whitelistRegexps = this._whitelistCache.get(config.whitelistPatterns);
+        if (!whitelistRegexps) {
+            whitelistRegexps = config.whitelistPatterns
+                .map((p) => { try { return new RegExp(p); } catch { return null; } })
+                .filter((r): r is RegExp => r !== null);
+            this._whitelistCache.set(config.whitelistPatterns, whitelistRegexps);
+        }
 
         const isWhitelisted = (value: string): boolean => {
             return whitelistRegexps.some((re) => re.test(value));
@@ -227,16 +235,25 @@ export class SecretScanner {
         }
 
         // ── Step 2: User-defined Custom Patterns ──
-        for (const custom of config.customPatterns) {
-            try {
-                const customRegex = new RegExp(custom.regex, 'g');
-                const matches = text.match(customRegex);
-                if (matches) {
-                    const uniqueMatches = [...new Set(matches)];
-                    uniqueMatches.forEach((match) => replaceSecret(match, custom.name));
-                }
-            } catch {
-                // Silently skip invalid user-defined patterns
+        let customRegexps = this._customPatternCache.get(config.customPatterns);
+        if (!customRegexps) {
+            customRegexps = config.customPatterns
+                .map((custom) => {
+                    try {
+                        return { name: custom.name, regex: new RegExp(custom.regex, 'g') };
+                    } catch {
+                        return null;
+                    }
+                })
+                .filter((r): r is { name: string; regex: RegExp } => r !== null);
+            this._customPatternCache.set(config.customPatterns, customRegexps);
+        }
+
+        for (const custom of customRegexps) {
+            const matches = text.match(custom.regex);
+            if (matches) {
+                const uniqueMatches = [...new Set(matches)];
+                uniqueMatches.forEach((match) => replaceSecret(match, custom.name));
             }
         }
 


### PR DESCRIPTION
💡 **What**: Added `WeakMap` caching for `whitelistPatterns` and `customPatterns` in `SecretScanner.redact`. By caching the compiled `RegExp` objects against the configuration array references, we skip creating new `RegExp` instances on every file scan.

🎯 **Why**: `SecretScanner.redact` is called thousands of times concurrently during "Scan Workspace", and calling `new RegExp(..., 'g')` over and over for the same configuration array creates severe CPU/memory overhead. Caching the compilation prevents this while avoiding memory leaks because `WeakMap` keys are garbage collected when the `config` array is.

📊 **Impact**: Massively reduces memory allocation and execution time during workspace scans. Reduces CPU usage during deep file scans, allowing `Promise.all` batches to process more smoothly.

🔬 **Measurement**: 
- Run "Scan Workspace" on a large project with custom patterns enabled before and after. Note the reduction in execution time and memory footprint (the extension host shouldn't spike as hard).
- All unit tests run against `SecretScanner` using `pnpm test` continue to pass perfectly, verifying that the `lastIndex` mutation of global Regex instances does not leak state across calls.

---
*PR created automatically by Jules for task [14660653718524508993](https://jules.google.com/task/14660653718524508993) started by @Sonofg0tham*