### PR TITLE
🛡️ Sentinel: [HIGH] Fix arbitrary command execution in webview

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Arbitrary Command Execution in Webview]
+**Vulnerability:** The webview message handler `onDidReceiveMessage` was blindly passing the `data.command` string to `vscode.commands.executeCommand` without validating that the command belonged to the extension.
+**Learning:** Webviews in VS Code run in a separate context and communicate via message passing. If a webview is compromised (e.g., via XSS), it can send arbitrary messages back to the extension host. Without validation, this allows the compromised webview to execute *any* VS Code command (like `workbench.action.terminal.new`, `vscode.open`, etc.), potentially leading to RCE or data exfiltration.
+**Prevention:** Always strictly validate and whitelist command strings received from webviews before passing them to `vscode.commands.executeCommand`. For example, ensure the command starts with the extension's prefix (e.g., `command.startsWith('quell.')`).

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -25,6 +25,11 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
+                    // Security: Strictly validate command strings from webview to prevent arbitrary command execution
+                    if (!data.command || typeof data.command !== 'string' || !data.command.startsWith('quell.')) {
+                        console.error('Quell: Blocked unauthorized command execution attempt from webview:', data.command);
+                        return;
+                    }
                     if (data.args) {
                         vscode.commands.executeCommand(data.command, ...data.args);
                     } else {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The webview message handler in `SidebarProvider.ts` directly passed the received `command` string to `vscode.commands.executeCommand` without validation.
🎯 **Impact:** If a webview was compromised (e.g., via XSS), an attacker could send a message to execute arbitrary VS Code commands (e.g., `workbench.action.terminal.new`, `vscode.open`), leading to potential local command execution or data exposure.
🔧 **Fix:** Added validation to strictly check that `data.command` starts with the expected extension prefix (`quell.`) before passing it to `vscode.commands.executeCommand`. If it does not, the command execution is blocked and logged.
✅ **Verification:** Ran `pnpm run compile` and `pnpm test` successfully. Verified that the new check rejects any command not starting with `quell.`.

---
*PR created automatically by Jules for task [12417023573687867575](https://jules.google.com/task/12417023573687867575) started by @Sonofg0tham*