### PR TITLE
⚡ Bolt: Cache split result in restore command

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Parallelize I/O-bound tasks in workspace scans
 **Learning:** Sequential `for` loops reading files block the event loop and increase latency for workspace scanning tasks. Since file reading and secret scanning don't depend on sequential execution order, they can be processed concurrently.
 **Action:** Parallelize I/O-bound tasks in workspace scans (like file reading and secret scanning) using `Promise.all` with `.map()` instead of sequential `for` loops to significantly reduce execution time.
+
+## 2026-04-03 - Cache split results in restore
+**Learning:** Repeatedly calling `.split(delimiter)` on the same string in a hot path creates redundant intermediate arrays.
+**Action:** Cache the result of `.split()` in a local variable if it needs to be reused for both counting and replacing via `.join()`.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -245,9 +245,11 @@ export function activate(context: vscode.ExtensionContext) {
             for (const placeholder of uniqueMatches) {
                 const realValue = await context.secrets.get(placeholder);
                 if (realValue) {
-                    const count = restoredText.split(placeholder).length - 1;
+                    // Cache the split result to avoid redundant array allocations
+                    const splitResult = restoredText.split(placeholder);
+                    const count = splitResult.length - 1;
                     if (count > 0) {
-                        restoredText = restoredText.split(placeholder).join(realValue);
+                        restoredText = splitResult.join(realValue);
                         restoredCount += count;
                     }
                 }


### PR DESCRIPTION
💡 What: Cache the split result in `extension.ts` restore command. 
🎯 Why: Prevents redundant array allocations. 
📊 Impact: O(1) instead of multiple splits, reduces memory overhead. 
🔬 Measurement: Run pnpm test.

---
*PR created automatically by Jules for task [158306149013925867](https://jules.google.com/task/158306149013925867) started by @Sonofg0tham*