### PR TITLE
🛡️ Sentinel: [HIGH] Fix arbitrary VS Code command execution in webview

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2025-04-03 - Webview Arbitrary Command Execution
+**Vulnerability:** The webview message handler in `SidebarProvider.ts` passed `data.command` directly to `vscode.commands.executeCommand()` without any validation. This meant if an attacker could execute an XSS payload inside the webview, they could issue any VS Code command, potentially leading to privilege escalation, file system access, or arbitrary code execution via the extension host.
+**Learning:** Even if CSP restricts external scripts, `executeCommand` is a critical boundary. All VS Code extensions must treat webview messages as untrusted input. The architecture using `quell.` prefixes for all legitimate commands provided a straightforward way to secure this boundary.
+**Prevention:** Always strictly validate or whitelist the `command` string before passing it to `vscode.commands.executeCommand()`. Ensure commands originate from the expected namespace (e.g., checking `command.startsWith('quell.')`).

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -25,10 +25,15 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
-                    if (data.args) {
-                        vscode.commands.executeCommand(data.command, ...data.args);
+                    // Security enhancement: Restrict commands to prevent arbitrary execution
+                    if (typeof data.command === 'string' && data.command.startsWith('quell.')) {
+                        if (data.args) {
+                            vscode.commands.executeCommand(data.command, ...data.args);
+                        } else {
+                            vscode.commands.executeCommand(data.command);
+                        }
                     } else {
-                        vscode.commands.executeCommand(data.command);
+                        console.error('Invalid command attempt:', data.command);
                     }
                     break;
             }


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** The webview message handler in `SidebarProvider.ts` accepted incoming messages and passed the `command` directly to `vscode.commands.executeCommand` without validation. If an attacker managed to exploit an XSS vulnerability within the webview, they could issue any VS Code command, potentially leading to arbitrary code execution, privilege escalation, or reading local files.
**🎯 Impact:** A compromised webview could take full control over the extension host capabilities via arbitrary command execution.
**🔧 Fix:** Added a strict validation check requiring that the `command` parameter is a string starting with `quell.` (the namespace for all legitimate Quell commands) before proceeding to execute it. Invalid requests are logged to the console and ignored.
**✅ Verification:** Compiled the project and ran unit tests. The fix prevents any command not starting with `quell.` from being executed by the webview handler while maintaining existing functionality. Documentation of this learning was added to the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [7114994031899359605](https://jules.google.com/task/7114994031899359605) started by @Sonofg0tham*