### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Arbitrary Command Execution via Webview IPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-20 - Webview Arbitrary Command Execution Vulnerability
+**Vulnerability:** The VS Code webview `onDidReceiveMessage` handler was directly passing the user-provided `data.command` string to `vscode.commands.executeCommand` without validation.
+**Learning:** This exposed the extension to arbitrary command execution vulnerabilities. If an attacker could inject malicious content into the webview (e.g., via XSS in a file path or other displayed data), they could execute any VS Code command on the user's machine, potentially accessing local files or running code.
+**Prevention:** Always validate and whitelist commands received from untrusted contexts like webviews before executing them. In this case, checking that the command starts with the expected extension prefix (`quell.`) prevents arbitrary commands from being run.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -25,6 +25,12 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
+                    // Security: Validate command string to prevent arbitrary command execution from potential XSS
+                    if (typeof data.command !== 'string' || !data.command.startsWith('quell.')) {
+                        console.warn(`Blocked unauthorized command execution request: ${data.command}`);
+                        break;
+                    }
+
                     if (data.args) {
                         vscode.commands.executeCommand(data.command, ...data.args);
                     } else {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Arbitrary Command Execution via Webview IPC. The webview `onDidReceiveMessage` listener was directly passing user-provided `data.command` strings to `vscode.commands.executeCommand()` without validation.
🎯 **Impact:** If an attacker achieved Cross-Site Scripting (XSS) within the webview, they could execute any registered VS Code command, potentially allowing them to access local files, open terminals, or run arbitrary shell commands on the user's machine.
🔧 **Fix:** Added validation to verify `data.command` is a string and strongly enforced that the command starts with the `quell.` namespace.
✅ **Verification:** Verified by running `pnpm run compile` and `pnpm test` to ensure changes didn't break builds. Verified code review indicates this prevents the exploit correctly.

---
*PR created automatically by Jules for task [11792175961532401483](https://jules.google.com/task/11792175961532401483) started by @Sonofg0tham*