### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary command execution from webview

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Prevent Arbitrary Command Execution from Webviews
+**Vulnerability:** The VS Code webview `onDidReceiveMessage` handler executed arbitrary commands passed in `data.command` via `vscode.commands.executeCommand` without validation.
+**Learning:** If a webview is compromised (e.g., via XSS), an attacker could send a message instructing the extension to execute any registered VS Code command, potentially leading to arbitrary code execution or access to sensitive workspace data.
+**Prevention:** Always strictly validate or whitelist command strings originating from untrusted contexts like webviews before passing them to execution APIs. In this case, checking if the command starts with the extension's legitimate prefix (`quell.`).

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -25,10 +25,16 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
-                    if (data.args) {
-                        vscode.commands.executeCommand(data.command, ...data.args);
+                    // Security: Strictly validate that the command is a legitimate Quell command.
+                    // This prevents arbitrary command execution vulnerabilities from potential XSS.
+                    if (typeof data.command === 'string' && data.command.startsWith('quell.')) {
+                        if (data.args) {
+                            vscode.commands.executeCommand(data.command, ...data.args);
+                        } else {
+                            vscode.commands.executeCommand(data.command);
+                        }
                     } else {
-                        vscode.commands.executeCommand(data.command);
+                        console.warn(`[Quell] Rejected unauthorized webview command execution request: ${data.command}`);
                     }
                     break;
             }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The VS Code webview `onDidReceiveMessage` handler was accepting arbitrary command strings (`data.command`) from the webview and passing them directly to `vscode.commands.executeCommand` without any validation.
🎯 **Impact:** If an attacker could achieve Cross-Site Scripting (XSS) within the webview, they could send a message instructing the extension to execute *any* registered VS Code command. This could lead to arbitrary code execution, reading/writing sensitive files, or manipulating the workspace without user consent.
🔧 **Fix:** Added a strict prefix check in `src/SidebarProvider.ts` to ensure that only commands starting with `quell.` are executed. Any unauthorized commands are rejected and logged as a warning.
✅ **Verification:** Ran `pnpm test` successfully. A manual code review confirms the `startsWith('quell.')` validation logic is in place before calling `executeCommand`.

---
*PR created automatically by Jules for task [10964951385809779227](https://jules.google.com/task/10964951385809779227) started by @Sonofg0tham*