### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary command execution in webview

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-03 - [CRITICAL] Webview Arbitrary Command Execution
+**Vulnerability:** The webview message handler `onDidReceiveMessage` in `SidebarProvider` passed unvalidated `data.command` directly to `vscode.commands.executeCommand`. This could allow a malicious actor or a successful XSS attack in the webview to execute arbitrary VS Code commands.
+**Learning:** Webviews run in an isolated context, but their messages are processed in the extension's main context. Trusting input blindly from the webview bridges this boundary dangerously, especially for powerful APIs like `executeCommand`.
+**Prevention:** Always validate and sanitize all messages received from webviews. For commands, enforce a strict whitelist or prefix check (e.g., verifying `command.startsWith('quell.')`) to ensure only authorized extension commands can be invoked.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -25,10 +25,15 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
-                    if (data.args) {
-                        vscode.commands.executeCommand(data.command, ...data.args);
+                    // Security Fix: Prevent arbitrary command execution from webview
+                    if (typeof data.command === 'string' && data.command.startsWith('quell.')) {
+                        if (data.args) {
+                            vscode.commands.executeCommand(data.command, ...data.args);
+                        } else {
+                            vscode.commands.executeCommand(data.command);
+                        }
                     } else {
-                        vscode.commands.executeCommand(data.command);
+                        console.warn(`[Quell] Blocked untrusted webview command: ${data.command}`);
                     }
                     break;
             }


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Arbitrary Command Execution via Webview. The `onDidReceiveMessage` handler in `SidebarProvider.ts` was passing unvalidated strings from the webview directly into `vscode.commands.executeCommand`. An XSS attack within the webview could trigger built-in VS Code commands (like `workbench.action.terminal.new`), leading to Remote Code Execution (RCE) on the host system.
🎯 **Impact**: A malicious actor could gain full execution rights on the developer's machine if they manage to inject a script into the webview.
🔧 **Fix**: Added strict input validation to verify that `data.command` is a string and strongly enforced a whitelist prefix (`quell.`). Any unauthorized commands are blocked and logged as warnings.
✅ **Verification**: Run `pnpm run compile && pnpm test` to ensure tests pass. No legitimate Quell commands are impacted, as they all use the `quell.` prefix natively.

---
*PR created automatically by Jules for task [5473894818768500977](https://jules.google.com/task/5473894818768500977) started by @Sonofg0tham*