### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary command execution in webview

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-20 - Webview Arbitrary Command Execution Vulnerability
+**Vulnerability:** Arbitrary command execution via VS Code Webview `onDidReceiveMessage` event.
+**Learning:** The webview accepted command strings directly from postMessage and passed them unvalidated to `vscode.commands.executeCommand`. If an attacker could inject XSS into the webview (e.g., through unescaped file paths), they could execute arbitrary built-in VS Code commands, potentially leading to local file access, terminal execution, or installing malicious extensions.
+**Prevention:** Always validate or whitelist command strings received from webviews before execution. Ensure all extension commands are prefixed uniquely (e.g., `quell.`) and check for this prefix before calling `executeCommand`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: 20.x
         version: 20.19.37
       '@types/vscode':
-        specifier: ^1.85.0
+        specifier: ^1.110.0
         version: 1.110.0
       typescript:
         specifier: ^5.3.3

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -25,10 +25,13 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
-                    if (data.args) {
-                        vscode.commands.executeCommand(data.command, ...data.args);
-                    } else {
-                        vscode.commands.executeCommand(data.command);
+                    // Security: Validate command to prevent arbitrary command execution via XSS
+                    if (typeof data.command === 'string' && data.command.startsWith('quell.')) {
+                        if (data.args) {
+                            vscode.commands.executeCommand(data.command, ...data.args);
+                        } else {
+                            vscode.commands.executeCommand(data.command);
+                        }
                     }
                     break;
             }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The webview accepted command strings directly from postMessage and passed them unvalidated to `vscode.commands.executeCommand`.
🎯 Impact: If an attacker could inject XSS into the webview, they could execute arbitrary built-in VS Code commands (e.g. `workbench.action.terminal.new`), potentially leading to local file access or terminal execution.
🔧 Fix: Updated the `onDidReceiveMessage` handler to validate that the command is a string and starts with `quell.` before passing it to `executeCommand`.
✅ Verification: Ran `pnpm test` and ensured the fix compiles and works properly. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [18350791824090079307](https://jules.google.com/task/18350791824090079307) started by @Sonofg0tham*