### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary command execution in Webview

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Arbitrary Command Execution in Webview
+**Vulnerability:** The VS Code Webview `onDidReceiveMessage` handler was directly passing `data.command` to `vscode.commands.executeCommand` without any validation. This allows a malicious webview (e.g., if XSS was possible) to execute any arbitrary VS Code command on the user's machine.
+**Learning:** Webviews run in a separate context but can communicate with the extension via postMessage. Untrusted or potentially compromised webview content should never dictate raw command strings to be executed by the highly privileged extension host context without strict validation.
+**Prevention:** Always validate or whitelist command names received from webviews. Since all legitimate commands for this extension are prefixed with `quell.`, enforcing that `command.startsWith('quell.')` prevents executing potentially dangerous built-in or external commands.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -25,6 +25,11 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
+                    // Security Check: Prevent arbitrary command execution from webviews
+                    if (typeof data.command !== 'string' || !data.command.startsWith('quell.')) {
+                        console.warn(`[Quell Sentinel] Blocked unauthorized command execution request: ${data.command}`);
+                        break;
+                    }
                     if (data.args) {
                         vscode.commands.executeCommand(data.command, ...data.args);
                     } else {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The VS Code Webview `onDidReceiveMessage` handler was directly passing the unvalidated `data.command` to `vscode.commands.executeCommand`. This could allow an attacker (if they managed to achieve XSS in the webview) to execute any arbitrary VS Code command on the user's machine, such as opening a terminal and running shell commands.
🎯 **Impact**: Remote Code Execution (RCE) via webview XSS.
🔧 **Fix**: Added a strict validation check to ensure that `data.command` is a string and starts with the expected extension prefix `quell.` before it is passed to `vscode.commands.executeCommand`. This effectively blocks unauthorized command execution requests.
✅ **Verification**: Ran `pnpm test` successfully. The code review confirmed the safety and correctness of the patch. Verified no regression to the standard extension flow.

---
*PR created automatically by Jules for task [17257635755264323223](https://jules.google.com/task/17257635755264323223) started by @Sonofg0tham*