### PR TITLE
🛡️ Sentinel: [HIGH] Fix Webview Command Injection Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Arbitrary Command Execution via Webview
+**Vulnerability:** The webview handler in `SidebarProvider.ts` executes whatever command is sent via `postMessage({type: 'action', command: ...})` without validating if the command is authorized.
+**Learning:** This is an arbitrary command execution vulnerability. Webviews run in a less trusted context. If an attacker injects malicious content (like through an unescaped file path triggering XSS or if the CSP is bypassed), they could send a message to execute arbitrary VS Code commands (e.g. `workbench.action.terminal.new` followed by terminal commands, or file deletion).
+**Prevention:** Strictly validate or whitelist command strings in `onDidReceiveMessage` before passing them to `vscode.commands.executeCommand`. Since legitimate extension commands are prefixed with `quell.`, enforcing that commands start with `quell.` blocks execution of standard VS Code workbench commands.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -25,6 +25,11 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
+                    // Security: Strictly validate command to prevent arbitrary command execution via webview XSS
+                    if (typeof data.command !== 'string' || !data.command.startsWith('quell.')) {
+                        console.warn(`Blocked unauthorized command execution attempt from webview: ${data.command}`);
+                        break;
+                    }
                     if (data.args) {
                         vscode.commands.executeCommand(data.command, ...data.args);
                     } else {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Webview Command Injection. The `SidebarProvider` `onDidReceiveMessage` handler was accepting arbitrary command strings without validation. If an attacker managed to execute JavaScript in the webview (e.g. through XSS), they could send messages to invoke any built-in VS Code workbench command.
🎯 Impact: Arbitrary command execution inside the user's workspace, potentially leading to unauthorized access, file manipulation, or running terminal commands.
🔧 Fix: Added strict validation ensuring `typeof data.command === 'string'` and `data.command.startsWith('quell.')`. This completely restricts webview actions to intended Quell commands.
✅ Verification: Ran `pnpm run compile` and `pnpm test` to ensure normal extension functionality remains unaffected. Checked that unauthorized command executions are logged and ignored.

---
*PR created automatically by Jules for task [14164961812638349218](https://jules.google.com/task/14164961812638349218) started by @Sonofg0tham*