### PR TITLE
🎨 Palette: Add ARIA live regions and descriptions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-15 - Stateful Toggle Button Accessibility in Webviews
 **Learning:** Toggle buttons (like "AI Indexing Shield") visually indicated their state via CSS classes (`.on`/`.off`) and text ("ON"/"OFF"), but lacked semantic `aria-pressed` states for screen readers. Furthermore, while primary buttons (`.btn-cta`, `.btn-tool`) had `:focus-visible` styles for keyboard navigation, the smaller `.toggle-btn` elements did not, making keyboard tabbing invisible.
 **Action:** Always ensure custom toggle buttons include dynamic `aria-pressed="true|false"` attributes and that ALL interactive elements receive explicit `:focus-visible` styling to support keyboard navigation in custom VS Code webviews.
+
+## 2024-05-16 - Dynamic Banners and Toggle Descriptions
+**Learning:** Found that dynamically injected warning banners (like the clipboard warning) lacked `role="alert"` and `aria-live="assertive"`, meaning screen readers would not announce them when they appeared. Also, toggle buttons lacked `aria-describedby` linking them to their detailed descriptive text below them, missing critical context for screen reader users.
+**Action:** Always ensure dynamically appearing notifications use `role="alert"` and `aria-live` attributes, and use `aria-describedby` to link interactive elements to adjacent explanatory text to provide complete context.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -136,7 +136,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 
         // ─── Clipboard warning ─────────────────────────────
         const clipboardBanner = this._clipboardWarning ? `
-            <div class="clipboard-warning">
+            <div class="clipboard-warning" role="alert" aria-live="assertive">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
                 <span>Secret in clipboard! Use <kbd>Ctrl+Shift+C</kbd> to safely copy.</span>
             </div>` : '';
@@ -714,10 +714,11 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                         </div>
                         <button class="toggle-btn ${this._aiShieldActive ? 'on' : 'off'}"
                             aria-pressed="${this._aiShieldActive ? 'true' : 'false'}"
+                            aria-describedby="shield-desc-ai"
                             title="${this._aiShieldActive ? 'Disable AI Indexing Shield' : 'Enable AI Indexing Shield'}"
                             onclick="vscode.postMessage({type:'action', command:'${shieldCmd}'})">${shieldLabel}</button>
                     </div>
-                    <div class="shield-desc">${shieldDesc}</div>
+                    <div id="shield-desc-ai" class="shield-desc">${shieldDesc}</div>
                 </div>
 
                 <!-- ── Clipboard Auto-Sanitize card ────── -->
@@ -729,10 +730,11 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                         </div>
                         <button class="toggle-btn ${autoSanitizeEnabled ? 'on' : 'off'}"
                             aria-pressed="${autoSanitizeEnabled ? 'true' : 'false'}"
+                            aria-describedby="shield-desc-clip"
                             title="${autoSanitizeEnabled ? 'Disable Clipboard Auto-Sanitize' : 'Enable Clipboard Auto-Sanitize'}"
                             onclick="vscode.postMessage({type:'action', command:'quell.toggleAutoSanitize'})">${autoSanitizeEnabled ? 'ON' : 'OFF'}</button>
                     </div>
-                    <div class="shield-desc">${autoSanitizeEnabled ? 'Actively securing copied secrets.' : 'Warns only when secrets are copied.'}</div>
+                    <div id="shield-desc-clip" class="shield-desc">${autoSanitizeEnabled ? 'Actively securing copied secrets.' : 'Warns only when secrets are copied.'}</div>
                 </div>
 
                 <div class="section-divider"></div>


### PR DESCRIPTION
💡 What: Added `role="alert"` and `aria-live="assertive"` to the dynamically injected clipboard warning banner. Added `aria-describedby` to the AI Shield and Auto-Sanitize toggle buttons, linking them to their respective descriptive text elements.
🎯 Why: Screen readers were not announcing the clipboard warning banner when it dynamically appeared because it lacked ARIA live region attributes. Additionally, toggle buttons lacked context for screen readers as they were not programmatically linked to their descriptions.
📸 Before/After: Visuals remain unchanged, but the DOM structure now includes the appropriate ARIA attributes and IDs.
♿ Accessibility: Improved screen reader announcements for dynamically injected alerts and provided better context for interactive toggle buttons.

---
*PR created automatically by Jules for task [16165696943686892771](https://jules.google.com/task/16165696943686892771) started by @Sonofg0tham*