### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary command execution via Webview IPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-09 - [CRITICAL] Arbitrary Command Execution via Webview IPC
+**Vulnerability:** The `SidebarProvider` webview accepted `onDidReceiveMessage` IPC messages from the Webview containing a `command` field and passed it directly to `vscode.commands.executeCommand(data.command)` without validation.
+**Learning:** Webviews must be treated as untrusted boundaries. Even if the webview HTML is generated locally, incoming IPC messages must be strictly validated against a static allowlist before execution to prevent arbitrary command execution vulnerabilities on the host machine.
+**Prevention:** Always validate `data.command` against a static Set of allowed commands (e.g. `ALLOWED_COMMANDS`) before calling `vscode.commands.executeCommand`. Do not blindly trust `data.command` from `onDidReceiveMessage`.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -9,6 +9,19 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
     private _aiShieldActive = false;
     private _clipboardWarning = false;
 
+    private static readonly ALLOWED_COMMANDS = new Set([
+        'quell.openFile',
+        'quell.enableAiShield',
+        'quell.disableAiShield',
+        'quell.toggleAutoSanitize',
+        'quell.copyRedacted',
+        'quell.sanitizedPaste',
+        'quell.scanWorkspace',
+        'quell.redactActiveFile',
+        'quell.restoreSecrets',
+        'quell.showLog'
+    ]);
+
     constructor(private readonly _extensionUri: vscode.Uri) { }
 
     public resolveWebviewView(
@@ -25,6 +38,10 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
+                    if (typeof data.command !== 'string' || !SidebarProvider.ALLOWED_COMMANDS.has(data.command)) {
+                        console.warn(`Quell Sidebar: blocked execution of unauthorized command '${data.command}'`);
+                        return;
+                    }
                     if (data.args) {
                         vscode.commands.executeCommand(data.command, ...data.args);
                     } else {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Arbitrary Command Execution via Webview IPC. The `SidebarProvider` webview accepted `onDidReceiveMessage` IPC messages containing a `command` field and passed it directly to `vscode.commands.executeCommand()` without any validation. A compromised webview could execute any VS Code command on the host.
🎯 Impact: Remote Code Execution (RCE) via arbitrary command execution if the webview context was compromised.
🔧 Fix: Implemented an explicit allowlist `ALLOWED_COMMANDS` in `SidebarProvider.ts` and validated incoming commands before passing them to `vscode.commands.executeCommand()`. Added a security warning log when blocked.
✅ Verification: Tested locally by verifying normal operations work and tests pass. Cleaned up temporary generated files. Recorded learnings in journal.

---
*PR created automatically by Jules for task [16454494642747952364](https://jules.google.com/task/16454494642747952364) started by @Sonofg0tham*