### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary command execution in Webview IPC

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-10 - Secure Webview Message Handling
+**Vulnerability:** The Webview message listener `onDidReceiveMessage` was passing `data.command` directly to `vscode.commands.executeCommand` without validation. This allowed an untrusted webview (potentially vulnerable to XSS) to execute arbitrary VS Code commands on the host machine.
+**Learning:** In VS Code extensions, webview content must be treated as untrusted. Directly executing commands from webview IPC messages without an allowlist enables remote code execution risks via standard VS Code commands.
+**Prevention:** Always implement a strict allowlist (e.g., using a `Set` of approved commands) and type-check inputs before executing actions derived from webview messages.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -2,6 +2,20 @@ import * as vscode from 'vscode';
 import { SecretScanner } from './SecretScanner';
 
 export class SidebarProvider implements vscode.WebviewViewProvider {
+    private static readonly ALLOWED_COMMANDS = new Set([
+        'quell.openFile',
+        'quell.enableAiShield',
+        'quell.disableAiShield',
+        'quell.toggleAutoSanitize',
+        'quell.copyRedacted',
+        'quell.sanitizedPaste',
+        'quell.scanWorkspace',
+        'quell.redactActiveFile',
+        'quell.restoreSecrets',
+        'quell.showLog',
+        'quell.openDemo'
+    ]);
+
     private _view?: vscode.WebviewView;
     private sessionScans = 0;
     private sessionSecrets = 0;
@@ -25,10 +39,12 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
-                    if (data.args) {
-                        vscode.commands.executeCommand(data.command, ...data.args);
-                    } else {
-                        vscode.commands.executeCommand(data.command);
+                    if (typeof data.command === 'string' && SidebarProvider.ALLOWED_COMMANDS.has(data.command)) {
+                        if (data.args) {
+                            vscode.commands.executeCommand(data.command, ...data.args);
+                        } else {
+                            vscode.commands.executeCommand(data.command);
+                        }
                     }
                     break;
             }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `SidebarProvider.ts` passed untrusted IPC messages (`data.command`) directly from the Webview into `vscode.commands.executeCommand` without validation. 
🎯 **Impact:** If the Webview context was compromised (e.g. via XSS or a malicious dependency), an attacker could pass arbitrary internal VS Code commands (like `workbench.action.terminal.sendSequence`) to gain Remote Code Execution (RCE) on the host machine running the extension.
🔧 **Fix:** Introduced strict allowlist validation using a statically defined `Set` containing only the required extension commands. We now check `typeof data.command === 'string'` and verify existence against `ALLOWED_COMMANDS` before execution.
✅ **Verification:** Ran the full test suite (`pnpm test`), passing successfully. A manual code review confirmed that the untrusted string boundary is correctly validated.

---
*PR created automatically by Jules for task [15495463512557585269](https://jules.google.com/task/15495463512557585269) started by @Sonofg0tham*