### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary command execution in webview

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability in VS Code Webview where malformed file paths were incorrectly escaped.
 **Learning:** Webview Content Security Policy allows 'unsafe-inline' scripts; all dynamic data must be rigorously HTML-escaped before interpolation into HTML strings. For inline JavaScript event handlers (e.g., onclick, onkeydown), data must be appropriately JavaScript-escaped AND HTML-escaped.
 **Prevention:** Always use dedicated `_escapeHtml` and `_escapeJs` methods when inserting variables into webview templates, keeping nested contexts in mind.
+## 2025-04-11 - [Fix Arbitrary Command Execution in Webview]
+**Vulnerability:** The VS Code webview `onDidReceiveMessage` callback executed arbitrary commands directly from the webview's IPC messages without validation.
+**Learning:** VS Code Webviews must be treated as untrusted boundaries. Even if the webview HTML is generated locally, incoming IPC messages must be strictly validated against a static allowlist before execution to prevent arbitrary command execution vulnerabilities on the host machine.
+**Prevention:** Always validate that incoming webview commands are strings and exist within a predefined `ALLOWED_COMMANDS` Set before passing them to `vscode.commands.executeCommand`.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -2,6 +2,19 @@ import * as vscode from 'vscode';
 import { SecretScanner } from './SecretScanner';
 
 export class SidebarProvider implements vscode.WebviewViewProvider {
+    private static readonly ALLOWED_COMMANDS = new Set([
+        'quell.openFile',
+        'quell.enableAiShield',
+        'quell.disableAiShield',
+        'quell.toggleAutoSanitize',
+        'quell.copyRedacted',
+        'quell.sanitizedPaste',
+        'quell.scanWorkspace',
+        'quell.redactActiveFile',
+        'quell.restoreSecrets',
+        'quell.showLog'
+    ]);
+
     private _view?: vscode.WebviewView;
     private sessionScans = 0;
     private sessionSecrets = 0;
@@ -25,10 +38,14 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
-                    if (data.args) {
-                        vscode.commands.executeCommand(data.command, ...data.args);
+                    if (typeof data.command === 'string' && SidebarProvider.ALLOWED_COMMANDS.has(data.command)) {
+                        if (data.args) {
+                            vscode.commands.executeCommand(data.command, ...data.args);
+                        } else {
+                            vscode.commands.executeCommand(data.command);
+                        }
                     } else {
-                        vscode.commands.executeCommand(data.command);
+                        console.warn(`[Quell Sentinel] Blocked unauthorized command execution attempt: ${data.command}`);
                     }
                     break;
             }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The VS Code webview `onDidReceiveMessage` handler permitted arbitrary VS Code command execution via IPC messages because any message of type `'action'` would pass its unsanitized `command` string directly to `vscode.commands.executeCommand`.
🎯 Impact: A compromised webview (e.g., via a previously found XSS bug) could execute arbitrary internal or external commands on the host machine.
🔧 Fix: Implemented strict IPC message validation by verifying that the incoming command is a valid string and matches an exact item in a predefined `ALLOWED_COMMANDS` Set. Unrecognized requests are safely logged as a warning.
✅ Verification: Ran `pnpm run compile` and `pnpm test` successfully. Verified that only allowed commands process and arbitrary inputs are ignored.

---
*PR created automatically by Jules for task [12500683585059153568](https://jules.google.com/task/12500683585059153568) started by @Sonofg0tham*