### PR TITLE
🎨 Palette: Add aria-describedby for a11y

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-15 - Stateful Toggle Button Accessibility in Webviews
 **Learning:** Toggle buttons (like "AI Indexing Shield") visually indicated their state via CSS classes (`.on`/`.off`) and text ("ON"/"OFF"), but lacked semantic `aria-pressed` states for screen readers. Furthermore, while primary buttons (`.btn-cta`, `.btn-tool`) had `:focus-visible` styles for keyboard navigation, the smaller `.toggle-btn` elements did not, making keyboard tabbing invisible.
 **Action:** Always ensure custom toggle buttons include dynamic `aria-pressed="true|false"` attributes and that ALL interactive elements receive explicit `:focus-visible` styling to support keyboard navigation in custom VS Code webviews.
+
+## 2024-05-16 - Connecting Descriptive Text to Toggle Buttons in Webviews
+**Learning:** Toggle buttons with descriptive text underneath them (like the AI Shield or Clipboard Auto-Sanitize descriptions) lacked a semantic connection. Screen readers would read the button label but miss the context provided by the adjacent description text.
+**Action:** Always link toggle buttons or custom interactive elements to their corresponding descriptive text using the `aria-describedby` attribute pointing to the ID of the descriptive text element. This ensures complete context is provided to screen reader users in VS Code webviews.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -714,10 +714,11 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                         </div>
                         <button class="toggle-btn ${this._aiShieldActive ? 'on' : 'off'}"
                             aria-pressed="${this._aiShieldActive ? 'true' : 'false'}"
+                            aria-describedby="ai-shield-desc"
                             title="${this._aiShieldActive ? 'Disable AI Indexing Shield' : 'Enable AI Indexing Shield'}"
                             onclick="vscode.postMessage({type:'action', command:'${shieldCmd}'})">${shieldLabel}</button>
                     </div>
-                    <div class="shield-desc">${shieldDesc}</div>
+                    <div class="shield-desc" id="ai-shield-desc">${shieldDesc}</div>
                 </div>
 
                 <!-- ── Clipboard Auto-Sanitize card ────── -->
@@ -729,10 +730,11 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                         </div>
                         <button class="toggle-btn ${autoSanitizeEnabled ? 'on' : 'off'}"
                             aria-pressed="${autoSanitizeEnabled ? 'true' : 'false'}"
+                            aria-describedby="auto-sanitize-desc"
                             title="${autoSanitizeEnabled ? 'Disable Clipboard Auto-Sanitize' : 'Enable Clipboard Auto-Sanitize'}"
                             onclick="vscode.postMessage({type:'action', command:'quell.toggleAutoSanitize'})">${autoSanitizeEnabled ? 'ON' : 'OFF'}</button>
                     </div>
-                    <div class="shield-desc">${autoSanitizeEnabled ? 'Actively securing copied secrets.' : 'Warns only when secrets are copied.'}</div>
+                    <div class="shield-desc" id="auto-sanitize-desc">${autoSanitizeEnabled ? 'Actively securing copied secrets.' : 'Warns only when secrets are copied.'}</div>
                 </div>
 
                 <div class="section-divider"></div>


### PR DESCRIPTION
💡 **What:** Added `aria-describedby` attributes to the "AI Indexing Shield" and "Clipboard Auto-Sanitize" toggle buttons in `SidebarProvider.ts` to link them semantically to their descriptive text `div`s (which now have matching IDs).

🎯 **Why:** Previously, screen reader users tabbing through the interface would only hear the button's label and toggle state (e.g., "ON / OFF"), but they would completely miss the explanatory text rendered immediately below the button (e.g., "Actively securing copied secrets."). This left them without critical context on what the toggles actually do.

📸 **Before/After:** No visual change. Purely semantic HTML improvements.

♿ **Accessibility:** This directly improves the screen reader experience by guaranteeing that adjacent, descriptive context is announced alongside the interactive toggle element.

---
*PR created automatically by Jules for task [4774973929627071940](https://jules.google.com/task/4774973929627071940) started by @Sonofg0tham*