### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary command execution in Webview IPC

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability in VS Code Webview where malformed file paths were incorrectly escaped.
 **Learning:** Webview Content Security Policy allows 'unsafe-inline' scripts; all dynamic data must be rigorously HTML-escaped before interpolation into HTML strings. For inline JavaScript event handlers (e.g., onclick, onkeydown), data must be appropriately JavaScript-escaped AND HTML-escaped.
 **Prevention:** Always use dedicated `_escapeHtml` and `_escapeJs` methods when inserting variables into webview templates, keeping nested contexts in mind.
+## 2026-04-13 - Prevent Arbitrary Command Execution in Webview IPC
+**Vulnerability:** Untrusted messages originating from Webview UI were passing arbitrary command strings directly to `vscode.commands.executeCommand(data.command)`.
+**Learning:** Even though Webview scripts were internal, any Cross-Site Scripting (XSS) or injected content could post valid-looking messages, leading to arbitrary extension/VS Code command execution on the host machine.
+**Prevention:** Always maintain a static Set allowlist (`ALLOWED_COMMANDS`) for all acceptable commands triggered via Webview IPC, and strictly validate the incoming `command` string before execution.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -2,6 +2,19 @@ import * as vscode from 'vscode';
 import { SecretScanner } from './SecretScanner';
 
 export class SidebarProvider implements vscode.WebviewViewProvider {
+    private static readonly ALLOWED_COMMANDS = new Set([
+        'quell.openFile',
+        'quell.enableAiShield',
+        'quell.disableAiShield',
+        'quell.toggleAutoSanitize',
+        'quell.copyRedacted',
+        'quell.sanitizedPaste',
+        'quell.scanWorkspace',
+        'quell.redactActiveFile',
+        'quell.restoreSecrets',
+        'quell.showLog'
+    ]);
+
     private _view?: vscode.WebviewView;
     private sessionScans = 0;
     private sessionSecrets = 0;
@@ -25,10 +38,14 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
-                    if (data.args) {
-                        vscode.commands.executeCommand(data.command, ...data.args);
+                    if (typeof data.command === 'string' && SidebarProvider.ALLOWED_COMMANDS.has(data.command)) {
+                        if (data.args) {
+                            vscode.commands.executeCommand(data.command, ...data.args);
+                        } else {
+                            vscode.commands.executeCommand(data.command);
+                        }
                     } else {
-                        vscode.commands.executeCommand(data.command);
+                        console.warn(`[Quell] Rejected unauthorized webview command: ${data.command}`);
                     }
                     break;
             }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Untrusted messages originating from Webview UI were passing arbitrary command strings directly to `vscode.commands.executeCommand(data.command)`. This means that if an attacker achieved Cross-Site Scripting (XSS) within the Webview (or if any content was otherwise injected), they could send valid-looking IPC messages to execute any installed VS Code extension command or built-in VS Code command on the user's host machine.
🎯 Impact: Remote Code Execution (RCE) / Arbitrary Command Execution on the host environment running VS Code via malicious Webview payloads.
🔧 Fix: Implemented a strict static `Set` allowlist (`SidebarProvider.ALLOWED_COMMANDS`) containing only the necessary and safe extension commands. Incoming `data.command` requests are now strictly validated against this allowlist before `executeCommand` is called. Unauthorized commands are rejected and logged.
✅ Verification: Tested against standard Webview actions (opening files, toggling settings, scanning workspace) ensuring legitimate functionality persists. Verified `pnpm compile` works, and ran the full `pnpm test` suite which passed successfully.

---
*PR created automatically by Jules for task [6042807355644509611](https://jules.google.com/task/6042807355644509611) started by @Sonofg0tham*