### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary command execution from webview IPC

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability in VS Code Webview where malformed file paths were incorrectly escaped.
 **Learning:** Webview Content Security Policy allows 'unsafe-inline' scripts; all dynamic data must be rigorously HTML-escaped before interpolation into HTML strings. For inline JavaScript event handlers (e.g., onclick, onkeydown), data must be appropriately JavaScript-escaped AND HTML-escaped.
 **Prevention:** Always use dedicated `_escapeHtml` and `_escapeJs` methods when inserting variables into webview templates, keeping nested contexts in mind.
+## 2025-04-14 - [Fix Arbitrary Command Execution in Webview IPC]
+**Vulnerability:** Untrusted IPC messages from VS Code Webviews (`onDidReceiveMessage`) were passing a `data.command` string directly to `vscode.commands.executeCommand` without validation.
+**Learning:** Webviews must be treated as untrusted boundaries. Passing unfiltered IPC payload data directly to sensitive APIs like `vscode.commands.executeCommand` allows for arbitrary command execution vulnerabilities on the host machine.
+**Prevention:** Always strictly validate `data.command` against a static allowlist of expected extension commands (e.g., using a `Set`) before executing it from a Webview IPC message.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -2,6 +2,19 @@ import * as vscode from 'vscode';
 import { SecretScanner } from './SecretScanner';
 
 export class SidebarProvider implements vscode.WebviewViewProvider {
+    private static readonly ALLOWED_COMMANDS = new Set([
+        'quell.openFile',
+        'quell.enableAiShield',
+        'quell.disableAiShield',
+        'quell.toggleAutoSanitize',
+        'quell.copyRedacted',
+        'quell.sanitizedPaste',
+        'quell.scanWorkspace',
+        'quell.redactActiveFile',
+        'quell.restoreSecrets',
+        'quell.showLog'
+    ]);
+
     private _view?: vscode.WebviewView;
     private sessionScans = 0;
     private sessionSecrets = 0;
@@ -25,10 +38,14 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
-                    if (data.args) {
-                        vscode.commands.executeCommand(data.command, ...data.args);
+                    if (typeof data.command === 'string' && SidebarProvider.ALLOWED_COMMANDS.has(data.command)) {
+                        if (data.args) {
+                            vscode.commands.executeCommand(data.command, ...data.args);
+                        } else {
+                            vscode.commands.executeCommand(data.command);
+                        }
                     } else {
-                        vscode.commands.executeCommand(data.command);
+                        console.warn(`Blocked execution of unauthorized command: ${data.command}`);
                     }
                     break;
             }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unfiltered Arbitrary Command Execution via Webview IPC in VS Code. The `onDidReceiveMessage` webview listener processed unvalidated string inputs and evaluated them directly using `vscode.commands.executeCommand(data.command)`.
🎯 **Impact:** If an attacker managed to find an XSS vector into the VS Code webview, they could manipulate this IPC layer to execute arbitrary commands locally on the system using VS Code's internal execution engine or built-in node scripts.
🔧 **Fix:** Implemented a secure trust boundary. Introduced a strict, statically-defined allowlist of allowed `quell.*` VS Code extension commands (`ALLOWED_COMMANDS` Set). The `onDidReceiveMessage` callback now rigorously validates that incoming string commands exist within this allowlist prior to execution.
✅ **Verification:** Verified by examining the modified file, successfully compiling via `tsc`, and completing all automated unit tests natively (`pnpm test`). Added logging of rejected webview commands. Added a journal entry to document the fix in `.Jules/sentinel.md`.

---
*PR created automatically by Jules for task [14446002461110532981](https://jules.google.com/task/14446002461110532981) started by @Sonofg0tham*