### PR TITLE
⚡ Bolt: Use O(1) map and replaceAll for faster string redaction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Parallelize I/O-bound tasks in workspace scans
 **Learning:** Sequential `for` loops reading files block the event loop and increase latency for workspace scanning tasks. Since file reading and secret scanning don't depend on sequential execution order, they can be processed concurrently.
 **Action:** Parallelize I/O-bound tasks in workspace scans (like file reading and secret scanning) using `Promise.all` with `.map()` instead of sequential `for` loops to significantly reduce execution time.
+## 2024-04-15 - O(1) map and replaceAll for faster string redaction
+**Learning:** `split().join()` allocates intermediate arrays; O(N) reverse-lookups in Maps are slow.
+**Action:** Use `replaceAll()` with a callback string replacer and O(1) reverse-lookup maps.

--- a/src/SecretScanner.ts
+++ b/src/SecretScanner.ts
@@ -183,6 +183,7 @@ export class SecretScanner {
     public static redact(text: string, config: ScannerConfig = DEFAULT_CONFIG): RedactResult {
         let redactedText = text;
         const secrets = new Map<string, string>();
+        const valueToPlaceholder = new Map<string, string>();
         const detectedTypes = new Set<string>();
 
         // Build whitelist regex set
@@ -218,23 +219,18 @@ export class SecretScanner {
             if (isPlaceholderAssignment(typeName, secretValue)) { return; }
 
             // Check if this exact secret value was already captured
-            let placeholder = '';
-            for (const [key, value] of secrets.entries()) {
-                if (value === secretValue) {
-                    placeholder = key;
-                    break;
-                }
-            }
+            let placeholder = valueToPlaceholder.get(secretValue) || '';
 
             if (!placeholder) {
                 const uuid = crypto.randomUUID().replace(/-/g, '').substring(0, 12);
                 placeholder = `{{SECRET_${uuid}}}`;
                 secrets.set(placeholder, secretValue);
+                valueToPlaceholder.set(secretValue, placeholder);
                 detectedTypes.add(typeName);
             }
 
-            // Use split/join for global replacement (safe for special regex chars in secrets)
-            redactedText = redactedText.split(secretValue).join(placeholder);
+            // Use replaceAll with callback for global replacement (safe for special regex chars in secrets)
+            redactedText = redactedText.replaceAll(secretValue, () => placeholder!);
         };
 
         // ── Step 1: Built-in Regex Patterns ──


### PR DESCRIPTION
💡 What: The optimization replaces an O(N) Map iteration inside `replaceSecret` with an O(1) `valueToPlaceholder` Map lookup, and avoids allocating intermediate arrays by changing `redactedText.split(secretValue).join(placeholder)` to `redactedText.replaceAll(secretValue, () => placeholder!)`. 
🎯 Why: The previous O(N) iteration scaled poorly when large amounts of distinct secrets were found in a block of text. Also, string splitting and joining created unnecessary array allocations during high-frequency redactions.
📊 Impact: Speeds up string redaction and lowers memory overhead on hot paths when running workspace-wide scans.
🔬 Measurement: Verified functionality locally running the Quell SecretScanner test suite. All regex parsing and placeholder generation tests still pass.

---
*PR created automatically by Jules for task [6092957188759455741](https://jules.google.com/task/6092957188759455741) started by @Sonofg0tham*