### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary command execution via webview

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability in VS Code Webview where malformed file paths were incorrectly escaped.
 **Learning:** Webview Content Security Policy allows 'unsafe-inline' scripts; all dynamic data must be rigorously HTML-escaped before interpolation into HTML strings. For inline JavaScript event handlers (e.g., onclick, onkeydown), data must be appropriately JavaScript-escaped AND HTML-escaped.
 **Prevention:** Always use dedicated `_escapeHtml` and `_escapeJs` methods when inserting variables into webview templates, keeping nested contexts in mind.
+## 2025-04-17 - [Fix Command Execution Vulnerability in VS Code Webview]
+**Vulnerability:** The webview accepted arbitrary commands via `postMessage` and blindly executed them with `vscode.commands.executeCommand(data.command)`, allowing a maliciously crafted workspace file displayed in the webview to execute arbitrary commands within the VS Code Extension Host.
+**Learning:** `vscode.WebviewViewProvider` does not automatically sandbox `onDidReceiveMessage` to your extension's commands. A maliciously injected link or script in the webview can invoke ANY registered command in the user's VS Code instance if `vscode.commands.executeCommand(data.command)` is called without validation.
+**Prevention:** Always use a static `Set` of explicitly allowed commands to strictly validate any command strings received from webviews before passing them to `executeCommand`.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -2,6 +2,19 @@ import * as vscode from 'vscode';
 import { SecretScanner } from '../packages/scanner/src';
 
 export class SidebarProvider implements vscode.WebviewViewProvider {
+    private static readonly ALLOWED_COMMANDS = new Set([
+        'quell.openFile',
+        'quell.enableAiShield',
+        'quell.disableAiShield',
+        'quell.toggleAutoSanitize',
+        'quell.copyRedacted',
+        'quell.sanitizedPaste',
+        'quell.scanWorkspace',
+        'quell.redactActiveFile',
+        'quell.restoreSecrets',
+        'quell.showLog'
+    ]);
+
     private _view?: vscode.WebviewView;
     private sessionScans = 0;
     private sessionSecrets = 0;
@@ -25,10 +38,14 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
-                    if (data.args) {
-                        vscode.commands.executeCommand(data.command, ...data.args);
+                    if (typeof data.command === 'string' && SidebarProvider.ALLOWED_COMMANDS.has(data.command)) {
+                        if (data.args) {
+                            vscode.commands.executeCommand(data.command, ...data.args);
+                        } else {
+                            vscode.commands.executeCommand(data.command);
+                        }
                     } else {
-                        vscode.commands.executeCommand(data.command);
+                        console.warn(`[Quell] Rejected unauthorized webview command execution: ${data.command}`);
                     }
                     break;
             }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The webview accepted arbitrary commands via `postMessage` and blindly executed them with `vscode.commands.executeCommand(data.command)`.
🎯 Impact: A maliciously crafted file displayed in the webview could execute arbitrary internal VS Code commands.
🔧 Fix: Add an `ALLOWED_COMMANDS` static Set and validate incoming messages in `onDidReceiveMessage` before calling `executeCommand`.
✅ Verification: Compiled successfully and tests pass.

---
*PR created automatically by Jules for task [5771298014318754847](https://jules.google.com/task/5771298014318754847) started by @Sonofg0tham*