### PR TITLE
⚡ Bolt: O(1) placeholder lookup and replaceAll optimization

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,0 +1,6 @@
+## 2026-04-19 - O(1) Lookups and replaceAll in Hot Paths
+**Learning:** In performance-critical hot paths involving text replacement, using `.split().join()` creates intermediate arrays, and performing linear  lookups over Map entries creates significant overhead during loops.
+**Action:** Replaced linear map searches with  reverse-lookup Maps, and substituted `.split().join()` with `.replaceAll()` using a callback to safely apply placeholders without invoking special replacement patterns, significantly reducing processing time.
+## 2024-05-24 - O(1) Lookups and replaceAll in Hot Paths
+**Learning:** In performance-critical hot paths involving text replacement, using `.split().join()` creates intermediate arrays, and performing linear O(N) lookups over Map entries creates significant overhead during loops.
+**Action:** Replaced linear map searches with O(1) reverse-lookup Maps, and substituted `.split().join()` with `.replaceAll()` using a callback to safely apply placeholders without invoking special replacement patterns, significantly reducing processing time.

--- a/packages/scanner/src/SecretScanner.ts
+++ b/packages/scanner/src/SecretScanner.ts
@@ -187,6 +187,8 @@ export class SecretScanner {
         let redactedText = text;
         const secrets = new Map<string, string>();
         const detectedTypes = new Set<string>();
+        // O(1) reverse lookup map to optimize placeholder lookup
+        const valueToPlaceholder = new Map<string, string>();
 
         // Build whitelist regex set
         const whitelistRegexps = config.whitelistPatterns
@@ -238,23 +240,18 @@ export class SecretScanner {
             if (isTestCredential(secretValue)) { return; }
 
             // Check if this exact secret value was already captured
-            let placeholder = '';
-            for (const [key, value] of secrets.entries()) {
-                if (value === secretValue) {
-                    placeholder = key;
-                    break;
-                }
-            }
+            let placeholder = valueToPlaceholder.get(secretValue) || '';
 
             if (!placeholder) {
                 const uuid = crypto.randomUUID().replace(/-/g, '').substring(0, 16);
                 placeholder = `{{SECRET_${uuid}}}`;
                 secrets.set(placeholder, secretValue);
+                valueToPlaceholder.set(secretValue, placeholder);
                 detectedTypes.add(typeName);
             }
 
-            // Use split/join for global replacement (safe for special regex chars in secrets)
-            redactedText = redactedText.split(secretValue).join(placeholder);
+            // Use replaceAll for faster global replacement (using a callback to avoid special replacement patterns)
+            redactedText = redactedText.replaceAll(secretValue, () => placeholder);
         };
 
         // ── Step 1: Built-in Regex Patterns ──


### PR DESCRIPTION
💡 What: Introduced a `valueToPlaceholder` `Map` to enable O(1) reverse-lookup for placeholders instead of a O(N) loop iterating over `secrets.entries()`. Additionally, substituted `.split(secretValue).join(placeholder)` with `.replaceAll(secretValue, () => placeholder)`.
🎯 Why: `secrets.entries()` requires an O(N) linear search for each new secret found to verify whether it had already been processed and cached. Furthermore, `.split().join()` allocates multiple intermediate string arrays, which causes performance issues on larger chunks of text.
📊 Impact: Considerably faster text redaction speeds during processing loops and lower memory footprint when scanning massive files. Reduces complexity of repeated string allocations.
🔬 Measurement: Verify changes in `packages/scanner/src/SecretScanner.ts` by reviewing the change from the `O(N)` linear search inside `replaceSecret` and `.replaceAll` usage instead of `.split().join()`. Run `pnpm run test` to verify no functionality has broken.

---
*PR created automatically by Jules for task [3457997684344688314](https://jules.google.com/task/3457997684344688314) started by @Sonofg0tham*