### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary command execution via Webview IPC

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** XSS vulnerability in VS Code Webview where malformed file paths were incorrectly escaped.
 **Learning:** Webview Content Security Policy allows 'unsafe-inline' scripts; all dynamic data must be rigorously HTML-escaped before interpolation into HTML strings. For inline JavaScript event handlers (e.g., onclick, onkeydown), data must be appropriately JavaScript-escaped AND HTML-escaped.
 **Prevention:** Always use dedicated `_escapeHtml` and `_escapeJs` methods when inserting variables into webview templates, keeping nested contexts in mind.
+## 2025-04-19 - [Fix Arbitrary Command Execution via VS Code Webview IPC]
+**Vulnerability:** The webview handler in `SidebarProvider.onDidReceiveMessage` blindly executed `vscode.commands.executeCommand(data.command)` directly from webview IPC without validation. If an attacker achieved XSS in the webview, they could execute arbitrary VS Code commands.
+**Learning:** VS Code Webviews must be treated as untrusted boundaries. Even if the webview HTML is generated locally, incoming IPC messages must be strictly validated against a static allowlist before execution to prevent arbitrary command execution vulnerabilities on the host machine.
+**Prevention:** Always implement an `ALLOWED_COMMANDS` Set in webview message handlers and verify `typeof data.command === 'string' && ALLOWED_COMMANDS.has(data.command)` before calling `vscode.commands.executeCommand()`.

--- a/src/SidebarProvider.ts
+++ b/src/SidebarProvider.ts
@@ -2,6 +2,19 @@ import * as vscode from 'vscode';
 import { SecretScanner } from '../packages/scanner/src';
 
 export class SidebarProvider implements vscode.WebviewViewProvider {
+    private static readonly ALLOWED_COMMANDS = new Set([
+        'quell.openFile',
+        'quell.enableAiShield',
+        'quell.disableAiShield',
+        'quell.toggleAutoSanitize',
+        'quell.copyRedacted',
+        'quell.sanitizedPaste',
+        'quell.scanWorkspace',
+        'quell.redactActiveFile',
+        'quell.restoreSecrets',
+        'quell.showLog'
+    ]);
+
     private _view?: vscode.WebviewView;
     private sessionScans = 0;
     private sessionSecrets = 0;
@@ -25,10 +38,14 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(data => {
             switch (data.type) {
                 case 'action':
-                    if (data.args) {
-                        vscode.commands.executeCommand(data.command, ...data.args);
+                    if (typeof data.command === 'string' && SidebarProvider.ALLOWED_COMMANDS.has(data.command)) {
+                        if (data.args) {
+                            vscode.commands.executeCommand(data.command, ...data.args);
+                        } else {
+                            vscode.commands.executeCommand(data.command);
+                        }
                     } else {
-                        vscode.commands.executeCommand(data.command);
+                        console.error('Quell: Blocked execution of unauthorized command from webview:', data.command);
                     }
                     break;
             }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `SidebarProvider.onDidReceiveMessage` handler was blindly calling `vscode.commands.executeCommand(data.command)` directly from webview IPC without any validation. If an attacker achieved Cross-Site Scripting (XSS) in the webview, they could use this unchecked IPC channel to execute arbitrary VS Code commands, leading to full Remote Code Execution (RCE) on the developer's host machine.
🎯 Impact: An attacker could bypass the webview sandbox and execute commands on the host machine.
🔧 Fix: Implemented an explicit allowlist (`SidebarProvider.ALLOWED_COMMANDS`) containing only the legitimate `quell.*` commands. Validated that incoming `data.command` exists in this list before execution.
✅ Verification: Ran `pnpm run compile` and `pnpm test`. All tests pass. Code review confirms the vulnerability is mitigated without regressions.

---
*PR created automatically by Jules for task [16347217449724632839](https://jules.google.com/task/16347217449724632839) started by @Sonofg0tham*