### PR TITLE
Fix all CodeQL code scanning alerts

### DIFF
--- a/packages/scanner/src/SecretScanner.ts
+++ b/packages/scanner/src/SecretScanner.ts
@@ -297,7 +297,7 @@ export class SecretScanner {
                 if (/^[a-z]+$/i.test(token)) { continue; }
 
                 // Skip URLs / file paths that aren't connection strings
-                if (/^https?:\/\//.test(token) && !/:\/\/[^:]+:[^@]+@/.test(token)) { continue; }
+                if (/^https?:\/\//.test(token) && !/:\/\/[^:@\s]{1,512}:[^@\s]{1,512}@/.test(token)) { continue; }
 
                 // Skip npm / yarn integrity hashes (sha256-, sha384-, sha512-)
                 if (/^sha[0-9]+-/i.test(token)) { continue; }

--- a/src/AiShieldManager.ts
+++ b/src/AiShieldManager.ts
@@ -106,18 +106,20 @@ export class AiShieldManager {
         const block = `\n${MARKER_START}\n${SHIELD_PATTERNS}\n${MARKER_END}\n`;
         let existing = '';
 
-        if (fs.existsSync(filePath)) {
+        try {
             existing = fs.readFileSync(filePath, 'utf-8');
             if (existing.includes(MARKER_START)) { return false; } // already shielded
-        }
+        } catch { /* file doesn't exist yet */ }
 
         fs.writeFileSync(filePath, existing + block, 'utf-8');
         return true;
     }
 
     private static _remove(filePath: string): void {
-        if (!fs.existsSync(filePath)) { return; }
-        let content = fs.readFileSync(filePath, 'utf-8');
+        let content: string;
+        try {
+            content = fs.readFileSync(filePath, 'utf-8');
+        } catch { return; }
         const regex = new RegExp(
             `\\n?${escapeRegex(MARKER_START)}[\\s\\S]*?${escapeRegex(MARKER_END)}\\n?`, 'g'
         );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as crypto from 'crypto';
-import { SecretScanner, ScannerConfig, DEFAULT_CONFIG } from '../packages/scanner/src';
+import { SecretScanner } from '../packages/scanner/src';
 import { EnvManager } from './EnvManager';
 import { Logger } from './Logger';
 import { StatusBar } from './StatusBar';


### PR DESCRIPTION
## Summary

- Remove unused `ScannerConfig` and `DEFAULT_CONFIG` imports from `extension.ts`
- Fix TOCTOU file system race conditions in `AiShieldManager.ts` by replacing `existsSync` + `readFileSync` with try/catch
- Fix potential ReDoS in `SecretScanner.ts` by adding `{1,512}` length limits to the URL credential-detection regex
- Dismissed two "missing regex anchor" alerts as false positives — intentionally unanchored so the scanner can match secrets anywhere within text

## Test plan

- [ ] `npm run compile` passes cleanly
- [ ] Run extension in Extension Host (F5) and verify AI Shield inject/remove still works
- [ ] Run `npm test` — all scanner tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)